### PR TITLE
add owasp defcon presence to agenda

### DIFF
--- a/meetings/202112.md
+++ b/meetings/202112.md
@@ -14,6 +14,7 @@ date: 2021-12-21
 - Call-in: [Zoom Meeting](https://us06web.zoom.us/j/89069321672?pwd=M212NUhmV1RwY05mVlZDNCtpOEFuQT09)
 
 ## Agenda
+* OWASP Defcon 2022 presence & budget approval details [here](https://docs.google.com/spreadsheets/d/1hf9OhyTzqoJbn2Ahuw5Jngj76G27aAn0w46-Wucslwc/edit?usp=sharing)
 
 ### CALL TO ORDER
 


### PR DESCRIPTION
adding the outreach committee's proposal for owasp presence to defcon 2022 and the suggested associated budget.
proposal follows guidelines for frugality :-) 