### PR TITLE
Fixed location typo: Avi Douglen

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -4,7 +4,7 @@
   linkedin: https://www.linkedin.com/in/avidouglen/
   title: Chair
   term-ends: 12/31/2025
-  location: Isreal 
+  location: Israel 
   description:  The Chair of the Board shall serve as the principal executive officer of the Foundation and provides strategic leadership and direction along with performing fiduciary and organizational requirements as defined in the OWASP Foundation bylaws.<br>
 - image: people/board-matt-tesauro.png
   name: Matt Tesauro 


### PR DESCRIPTION
Avi Douglen's location is "Isreal" - this PR corrects it to "Israel"