### PR TITLE
Correct the vote for Diego Martins

### DIFF
--- a/meetings-historical/2025/202501.md
+++ b/meetings-historical/2025/202501.md
@@ -114,7 +114,7 @@ Motion: "Resolved, that the Board appoints Diego Silva Martins to the OWASP Boar
 **Second:** Avi Douglen
 
 **Results:**
-Passes  5-1
+Passes  5 YES, 0 NO, 1 ABSTAIN
 
 ### NEW BUSINESS
 


### PR DESCRIPTION
The vote was not 5 YES - 1 NO, it was 5 YES, 0 NO, 1 ABSTAIN. 

This corrects the record, and will need to be re-approved in the March board meeting. 